### PR TITLE
chore(eslint): add ESlint recommended extension

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,16 @@
 {
-    "extends": "google",
-    "parserOptions": {
+  "extends": "eslint:recommended",
+  "parserOptions": {
     "ecmaVersion": 6
-    },
-    "rules": {
-      "no-console": "off",
-      "strict": ["error", "global"],
-      "curly": "warn"
-    }
+  },
+  "env": {
+    "browser": true,
+    "es6": true,
+    "node": true
+  },
+  "rules": {
+    "no-console": "off",
+    "strict": ["error", "global"],
+    "curly": "warn"
+  }
 }

--- a/README.md
+++ b/README.md
@@ -23,3 +23,9 @@ Watch for changes in `.scss` files:
 ```sh
 $ gulp
 ```
+
+## Linters
+
+```shell
+$ eslint .
+```

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const gulp = require('gulp');
 const sass = require('gulp-sass');
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "homepage": "https://github.com/bellangerq/wysiwyg-editor#readme",
   "devDependencies": {
     "eslint": "^4.3.0",
-    "eslint-config-google": "^0.9.1",
     "gulp": "^3.9.1",
     "gulp-sass": "^3.1.0"
   }


### PR DESCRIPTION
Correctly configure ESLint with recommended extension.

Now if you run `eslint .` or use a live ESLint feature editor, you should see some errors. It's up to you to fix them! 😛 

![eslint errors](https://dsh.re/d5015)